### PR TITLE
feat: Add a Send Event RSVP Response Sample with check event particip…

### DIFF
--- a/code-samples/calendar-event/python/send_event_RSVP_response/README.md
+++ b/code-samples/calendar-event/python/send_event_RSVP_response/README.md
@@ -1,0 +1,56 @@
+# SendEventRSVPResponse
+
+This sample will show you to easily send RSVP Response with the Nylas Python SDK.
+
+You can follow along step-by-step in our blog post ["How to Send RSVP Response with the Nylas Python SDK"](https://www.nylas.com/blog/category/developers/).
+
+## Setup
+
+### System dependencies
+
+- Python v3.x
+
+### Gather environment variables
+
+You'll need the following values:
+
+```text
+API_KEY = ""
+GRANT_ID = ""
+CALENDAR_ID = ""
+EVENT_ID = ""
+```
+
+Add the above values to a new `.env` file:
+
+```bash
+$ touch .env # Then add your env variables
+```
+
+### Install dependencies
+
+```bash
+$ pip3 install nylas
+$ pip3 install python-dotenv
+```
+
+## Usage
+
+Run the script using the `python3` command:
+
+```bash
+$ python3 SendEventRSVPResponse.py
+```
+
+When your message is successfully sent, you'll get the following output in your terminal:
+
+```text
+RSVP Response succeed, request id: 11111111
+Event: Nylas RSVP Response Test id: 11111111
+Participant: email@test.com status: yes
+Participant: email@test2.com status: maybe
+```
+
+## Learn more
+
+Visit our [Nylas Python SDK documentation](https://developer.nylas.com/docs/v3-beta/) to learn more.

--- a/code-samples/calendar-event/python/send_event_RSVP_response/SendEventRSVPResponse.py
+++ b/code-samples/calendar-event/python/send_event_RSVP_response/SendEventRSVPResponse.py
@@ -1,0 +1,42 @@
+# Import your dependencies
+import os
+from nylas import Client
+from dotenv import load_dotenv
+
+# Load your env variables
+load_dotenv()
+
+# Set Nylas API_KEY
+nylas = Client(
+    api_key=os.environ.get("API_KEY")
+)
+
+# Read settings from environment variables
+grant_id = os.environ.get("GRANT_ID")
+calendar_id = os.environ.get("CALENDAR_ID")
+event_id = os.environ.get("EVENT_ID")
+
+# Set status confirmation
+status = 'maybe'   # yes | no | maybe
+
+# If the calendar_id is another than the email please be sure to point to correct calendar_id
+try:
+    response = nylas.events.send_rsvp(grant_id, event_id, {"status": status}, {"calendar_id": calendar_id})
+except Exception as e:
+    print(f'An error occurred, exception {str(e)}')
+else:
+    print(f'RSVP Response succeed, request id: {response.request_id}')
+
+
+# Check event RSVP status
+try:
+    response = nylas.events.find(grant_id, event_id, {"calendar_id": calendar_id})
+except Exception as e:
+    print(f'An error occurred, exception {str(e)}')
+else:
+    event = response.data
+    print(f'Event: {event.title}, id: {event.id}')
+
+    # Search for participant email
+    for participant in event.participants:
+        print(f'Participant: {participant.email},  status: {participant.status}')


### PR DESCRIPTION
…ant status

The README.md file was copied from other sample v2, modified for Send Event RSVP Response Setup, pointing to SDK v3 Documentation and general blog page because not found blog for this case.

resolves: #56

## PR Acceptance Criteria

## Guidelines
* [x] PR follows the [Contributing guidelines](https://github.com/nylas-samples/nylas-hacktoberfest-2023/blob/main/CONTRIBUTION.md)?
* [x] PR Adheres to our [Code of Conduct](https://github.com/nylas-samples/nylas-hacktoberfest-2023/blob/main/CODE_OF_CONDUCT.md)?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Code complete
* [x] A `README.md` available describing how to setup and test the code?
* [x] The code sample in the correct location (i.e. `email/node/read-email`)?
* [x] Link added to the repository readme (view `# Code Snippets created by the Nylas Community` with examples) describing what the code sample does for others to try out
* [x] The code can be run using Github Codespaces, so the maintainer can try out the code sample remotely to ensure everything is working before we accept the PR.

## For PR Reviewer use
* [x] Purpose of code sample is clear
* [x] The code sample is readable
* [x] Steps try out the code are provided
* [x] Code sample runs on codespaces environment
* [x] Code works as expected
* [x] PR labels added